### PR TITLE
Update Piper download references

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ tecnologías libres y de alto rendimiento.
    cd Reader
    ```
 2. **Descarga Piper**
-   - Visita <https://github.com/rhasspy/piper/releases/latest>.
-   - Descarga el ZIP `piper_windows_amd64` y extrae `piper.exe` en
+   - Visita <https://github.com/OHF-Voice/piper1-gpl/releases/latest>.
+   - Descarga el ZIP `piper1-gpl_windows_amd64` y extrae `piper.exe` en
      `runtime\piper\` dentro del repo (crea la carpeta si hace falta).
 3. **Descarga al menos una voz española**
    - En la misma release, busca un modelo de 22.05 kHz (calidad *high*), por

--- a/scripts/windows/README.md
+++ b/scripts/windows/README.md
@@ -13,8 +13,8 @@ usando `-f`.
 ### Requisitos previos
 
 1. **Descargar Piper**
-   - Ve a <https://github.com/rhasspy/piper/releases/latest> y baja el ZIP
-     `piper_windows_amd64`.
+   - Ve a <https://github.com/OHF-Voice/piper1-gpl/releases/latest> y baja el ZIP
+     `piper1-gpl_windows_amd64`.
    - Extrae `piper.exe` en `runtime/piper/` dentro del proyecto.
 2. **Descargar una voz es_ES (22.05 kHz, calidad high)**
    - En la misma página de releases, ubica una voz como

--- a/scripts/windows/run_piper_demo.bat
+++ b/scripts/windows/run_piper_demo.bat
@@ -20,8 +20,8 @@ set OUTPUT_WAV=%RUNTIME_DIR%\out.wav
 
 if not exist "%PIPER_EXE%" (
   echo [ERROR] Piper no encontrado en %PIPER_EXE%.
-  echo         Descarga piper_windows_amd64.zip desde:
-  echo         https://github.com/rhasspy/piper/releases/latest
+  echo         Descarga piper1-gpl_windows_amd64.zip desde:
+  echo         https://github.com/OHF-Voice/piper1-gpl/releases/latest
   echo         y extrae piper.exe en runtime\piper\
   exit /b 1
 )


### PR DESCRIPTION
## Summary
- point the Windows setup instructions to the OHF-Voice/piper1-gpl releases
- update ZIP filename references in documentation and helper script output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc0212fc488328a674587dd4cc6ea8