### PR TITLE
Update Piper instructions for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@ tecnologías libres y de alto rendimiento.
    git clone https://github.com/<tu-usuario>/Reader.git
    cd Reader
    ```
-2. **Descarga Piper**
-   - Visita <https://github.com/OHF-Voice/piper1-gpl/releases/latest>.
-   - Descarga el ZIP `piper1-gpl_windows_amd64` y extrae `piper.exe` en
-     `runtime\piper\` dentro del repo (crea la carpeta si hace falta).
+2. **Obtén Piper para Windows**
+   - La última release de <https://github.com/OHF-Voice/piper1-gpl/releases/latest>
+     (verificada manualmente) no incluye binarios listos para Windows.
+   - Instala la rueda oficial con `python -m pip install --upgrade piper-tts` y
+     copia `piper.exe` desde tu entorno de Python (normalmente
+     `%USERPROFILE%\AppData\Local\Programs\Python\Python311\Scripts\piper.exe`
+     o `venv\Scripts\piper.exe`) a `runtime\piper\` dentro del repo (crea la
+     carpeta si hace falta).
 3. **Descarga al menos una voz española**
    - En la misma release, busca un modelo de 22.05 kHz (calidad *high*), por
      ejemplo `es_ES-aisa-high.onnx` o `es_ES-carlfm-high.onnx`.

--- a/scripts/windows/README.md
+++ b/scripts/windows/README.md
@@ -12,10 +12,12 @@ usando `-f`.
 
 ### Requisitos previos
 
-1. **Descargar Piper**
-   - Ve a <https://github.com/OHF-Voice/piper1-gpl/releases/latest> y baja el ZIP
-     `piper1-gpl_windows_amd64`.
-   - Extrae `piper.exe` en `runtime/piper/` dentro del proyecto.
+1. **Instalar Piper**
+   - La release más reciente en <https://github.com/OHF-Voice/piper1-gpl/releases/latest>
+     (comprobada manualmente) ya no publica un ZIP con binario para Windows.
+   - Ejecuta `python -m pip install --upgrade piper-tts` (puede ser en un entorno
+     virtual) y copia `piper.exe` desde la carpeta `Scripts/` del entorno a
+     `runtime/piper/` dentro del proyecto.
 2. **Descargar una voz es_ES (22.05 kHz, calidad high)**
    - En la misma página de releases, ubica una voz como
      `es_ES-carlfm-high.onnx` o `es_ES-aisa-high.onnx`.

--- a/scripts/windows/run_piper_demo.bat
+++ b/scripts/windows/run_piper_demo.bat
@@ -20,9 +20,8 @@ set OUTPUT_WAV=%RUNTIME_DIR%\out.wav
 
 if not exist "%PIPER_EXE%" (
   echo [ERROR] Piper no encontrado en %PIPER_EXE%.
-  echo         Descarga piper1-gpl_windows_amd64.zip desde:
-  echo         https://github.com/OHF-Voice/piper1-gpl/releases/latest
-  echo         y extrae piper.exe en runtime\piper\
+  echo         Instala la rueda con: python -m pip install --upgrade piper-tts
+  echo         y copia piper.exe desde la carpeta Scripts\ de tu Python a runtime\piper\
   exit /b 1
 )
 


### PR DESCRIPTION
## Summary
- document that the latest piper1-gpl release no longer ships a Windows binary
- recommend installing Piper via the piper-tts wheel and copying piper.exe into runtime/piper
- align the Windows demo batch script error messaging with the new guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc03782d0c83288b1c5bfbb5806da8