### PR TITLE
Add root batch wrapper for Piper demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ tecnologías libres y de alto rendimiento.
    - Copia el `.onnx` a `assets\voices\es_ES\` (crea la carpeta si no existe).
 4. **Ejecuta la demo por lotes**
    ```bat
-   scripts\windows\run_piper_demo.bat "Hola, esto es una prueba."
+   run_piper_demo.bat "Hola, esto es una prueba."
    ```
    El resultado se guardará en `runtime\out.wav` y podrás abrirlo con el
-   reproductor predeterminado.
+   reproductor predeterminado. Si prefieres mantener los scripts agrupados,
+   sigue disponible `scripts\windows\run_piper_demo.bat` (el nuevo `run_piper_demo.bat`
+   simplemente delega en él para que la UI y futuros flujos de trabajo no se
+   vean afectados).
 
 > ℹ️  Para más opciones (usar archivos de texto, cambiar el modelo con
 > `PIPER_VOICE`, etc.) consulta `scripts/windows/README.md`.

--- a/run_piper_demo.bat
+++ b/run_piper_demo.bat
@@ -1,0 +1,21 @@
+@echo off
+setlocal enabledelayedexpansion
+
+rem Wrapper para tener el demo de Piper a mano desde la raíz del repo.
+rem Delegamos en scripts\windows\run_piper_demo.bat para no duplicar lógica.
+
+set "REPO_ROOT=%~dp0"
+pushd "%REPO_ROOT%" >nul
+
+set "DEMO_SCRIPT=scripts\windows\run_piper_demo.bat"
+if not exist "%DEMO_SCRIPT%" (
+    echo [ERROR] No se encontró %%DEMO_SCRIPT%%. Asegúrate de clonar el repo completo.
+    popd >nul
+    exit /b 1
+)
+
+call "%DEMO_SCRIPT%" %*
+set "ERRORLEVEL_COPY=%ERRORLEVEL%"
+
+popd >nul
+exit /b %ERRORLEVEL_COPY%

--- a/scripts/windows/README.md
+++ b/scripts/windows/README.md
@@ -39,3 +39,8 @@ scripts\windows\run_piper_demo.bat "Probando otra voz"
 
 El audio se guardará en `runtime/out.wav`. Puedes reproducirlo con cualquier
 player, por ejemplo, doble clic en el Explorador o usando `start runtime\out.wav`.
+
+> 💡 Desde la raíz del repositorio ahora también puedes ejecutar `run_piper_demo.bat`
+> directamente. Ese archivo no duplica la lógica: simplemente reenvía la llamada a
+> `scripts\windows\run_piper_demo.bat`, de modo que cualquier automatización de la UI
+> o tareas futuras siga funcionando sin cambios.


### PR DESCRIPTION
## Summary
- add a root-level `run_piper_demo.bat` wrapper so the Piper demo is easy to launch
- refresh the Windows documentation to mention the shortcut without impacting UI tooling

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc2fd2d4f48328b446fe6c7a8f0633