### PR TITLE
Ensure batch scripts use CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bat text eol=crlf


### PR DESCRIPTION
## Summary
- add a `.gitattributes` entry to enforce CRLF line endings for Windows batch scripts
- renormalize existing batch helpers so they comply with the new setting

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc5bbf671883288c0bf562f4583ffb