### PR TITLE
Implement Tauri backend speech and import commands

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "reader-tauri"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0"
+flexi_logger = "0.27"
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+shlex = "1.2"
+thiserror = "1.0"
+tauri = { version = "1.5", features = ["macros"] }
+
+[dev-dependencies]
+assert_fs = "1.0"
+serde_json = "1.0"
+tempfile = "3.8"
+
+[build-dependencies]
+tauri-build = { version = "1.5", features = [] }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build();
+}

--- a/src-tauri/src/cmds/import_epub.rs
+++ b/src-tauri/src/cmds/import_epub.rs
@@ -1,0 +1,102 @@
+use std::path::PathBuf;
+
+use log::info;
+
+use super::{import_pdf, CommandError};
+use import_pdf::ImportResponse;
+
+#[derive(Debug, serde::Deserialize)]
+pub struct ImportEpubRequest {
+    pub path: PathBuf,
+}
+
+pub fn import_epub(request: ImportEpubRequest) -> Result<ImportResponse, CommandError> {
+    info!("Importing EPUB {}", request.path.display());
+    import_pdf::run_importer(
+        "READER_IMPORT_EPUB_COMMAND",
+        "scripts/py/import_epub.py",
+        &request.path,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::TempDir;
+    use std::fs;
+
+    struct EnvGuard {
+        key: &'static str,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: String) -> Self {
+            std::env::set_var(key, value);
+            Self { key }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var(self.key);
+        }
+    }
+
+    fn write_mock_importer(temp: &TempDir, body: &str) -> EnvGuard {
+        let script_path = temp.path().join("importer.py");
+        fs::write(&script_path, body).unwrap();
+        EnvGuard::set(
+            "READER_IMPORT_EPUB_COMMAND",
+            format!("python3 {}", script_path.display()),
+        )
+    }
+
+    fn sample_request(temp: &TempDir) -> ImportEpubRequest {
+        let epub = temp.path().join("book.epub");
+        fs::write(&epub, b"epub").unwrap();
+        ImportEpubRequest { path: epub }
+    }
+
+    #[test]
+    fn successful_import_parses_json() {
+        let temp = TempDir::new().unwrap();
+        let _guard = write_mock_importer(
+            &temp,
+            r#"import json, sys
+print(json.dumps({
+    "title": "Libro",
+    "language": "es",
+    "sections": [
+        {"heading": "Capítulo 1", "content": "Hola"}
+    ]
+}))
+"#,
+        );
+        let request = sample_request(&temp);
+        let response = import_epub(request).unwrap();
+        assert_eq!(response.document.title.as_deref(), Some("Libro"));
+    }
+
+    #[test]
+    fn importer_failure_is_reported() {
+        let temp = TempDir::new().unwrap();
+        let _guard = write_mock_importer(
+            &temp,
+            "import sys\nsys.stderr.write('kaput')\nsys.exit(2)",
+        );
+        let request = sample_request(&temp);
+        let error = import_epub(request).unwrap_err();
+        assert_eq!(error.code, import_pdf::ERROR_SCRIPT_FAILED);
+        assert_eq!(error.details.unwrap(), "kaput");
+    }
+
+    #[test]
+    fn missing_file_returns_error() {
+        let temp = TempDir::new().unwrap();
+        let request = ImportEpubRequest {
+            path: temp.path().join("missing.epub"),
+        };
+        let error = import_epub(request).unwrap_err();
+        assert_eq!(error.code, import_pdf::ERROR_IO);
+    }
+}

--- a/src-tauri/src/cmds/import_pdf.rs
+++ b/src-tauri/src/cmds/import_pdf.rs
@@ -1,0 +1,289 @@
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Stdio},
+    time::Instant,
+};
+
+use log::{error, info};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use shlex::Shlex;
+
+use super::CommandError;
+
+pub const ERROR_SCRIPT_FAILED: &str = "SCRIPT_FAILED";
+pub const ERROR_INVALID_JSON: &str = "INVALID_JSON";
+pub const ERROR_INVALID_RESPONSE: &str = "INVALID_RESPONSE";
+pub const ERROR_IO: &str = "IO_ERROR";
+
+#[derive(Debug, Deserialize)]
+pub struct ImportPdfRequest {
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct DocumentSection {
+    pub id: Option<String>,
+    pub heading: Option<String>,
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct ImportedDocument {
+    pub title: Option<String>,
+    pub language: Option<String>,
+    pub sections: Vec<DocumentSection>,
+    pub metadata: Value,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct ImportResponse {
+    pub document: ImportedDocument,
+    pub warnings: Vec<String>,
+    pub duration_ms: u128,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawImport {
+    title: Option<String>,
+    language: Option<String>,
+    sections: Vec<RawSection>,
+    #[serde(default)]
+    metadata: Option<Map<String, Value>>,
+    #[serde(default)]
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSection {
+    id: Option<String>,
+    heading: Option<String>,
+    content: Option<String>,
+}
+
+fn build_command(env_key: &str, default_script: &str) -> Result<Command, CommandError> {
+    if let Some(raw_command) = std::env::var_os(env_key) {
+        let raw_command = raw_command.to_string_lossy().into_owned();
+        let mut shlex = Shlex::new(&raw_command);
+        let mut parts: Vec<String> = shlex.collect();
+        if parts.is_empty() {
+            return Err(CommandError::new(
+                ERROR_IO,
+                format!("{env_key} is empty"),
+                None,
+            ));
+        }
+        let program = parts.remove(0);
+        let mut command = Command::new(program);
+        for part in parts {
+            command.arg(part);
+        }
+        Ok(command)
+    } else {
+        let mut command = Command::new("python");
+        command.arg(default_script);
+        Ok(command)
+    }
+}
+
+pub(crate) fn run_importer(
+    env_key: &str,
+    default_script: &str,
+    path: &PathBuf,
+) -> Result<ImportResponse, CommandError> {
+    if !path.exists() {
+        return Err(CommandError::new(
+            ERROR_IO,
+            format!("File not found: {}", path.display()),
+            None,
+        ));
+    }
+
+    let mut command = build_command(env_key, default_script)?;
+    command.arg(path);
+    command.stdin(Stdio::null());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    let start = Instant::now();
+    let output = command.output().map_err(|err| {
+        CommandError::new(ERROR_IO, "Failed to run importer", Some(err.to_string()))
+    })?;
+    let duration_ms = start.elapsed().as_millis();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+    if !output.status.success() {
+        error!(
+            "Importer {env_key} failed with status {:?}: {}",
+            output.status.code(),
+            stderr
+        );
+        return Err(CommandError::new(
+            ERROR_SCRIPT_FAILED,
+            format!("Importer exited with status {:?}", output.status.code()),
+            if stderr.is_empty() { None } else { Some(stderr) },
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let raw: RawImport = serde_json::from_str(&stdout).map_err(|err| {
+        CommandError::new(
+            ERROR_INVALID_JSON,
+            "Importer returned invalid JSON",
+            Some(err.to_string()),
+        )
+    })?;
+
+    let sections = raw
+        .sections
+        .into_iter()
+        .map(|section| {
+            let content = section.content.ok_or_else(|| {
+                CommandError::new(
+                    ERROR_INVALID_RESPONSE,
+                    "Section is missing the content field",
+                    None,
+                )
+            })?;
+            Ok(DocumentSection {
+                id: section.id,
+                heading: section.heading,
+                content,
+            })
+        })
+        .collect::<Result<Vec<_>, CommandError>>()?;
+
+    let metadata = raw
+        .metadata
+        .map(Value::Object)
+        .unwrap_or(Value::Null);
+
+    Ok(ImportResponse {
+        document: ImportedDocument {
+            title: raw.title,
+            language: raw.language,
+            sections,
+            metadata,
+        },
+        warnings: raw.warnings,
+        duration_ms,
+    })
+}
+
+pub fn import_pdf(request: ImportPdfRequest) -> Result<ImportResponse, CommandError> {
+    info!("Importing PDF {}", request.path.display());
+    run_importer(
+        "READER_IMPORT_PDF_COMMAND",
+        "scripts/py/import_pdf.py",
+        &request.path,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::TempDir;
+
+    struct EnvGuard {
+        key: &'static str,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: String) -> Self {
+            std::env::set_var(key, value);
+            Self { key }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var(self.key);
+        }
+    }
+
+    fn write_mock_importer(temp: &TempDir, body: &str) -> EnvGuard {
+        let script_path = temp.path().join("importer.py");
+        fs::write(&script_path, body).unwrap();
+        EnvGuard::set(
+            "READER_IMPORT_PDF_COMMAND",
+            format!("python3 {}", script_path.display()),
+        )
+    }
+
+    fn sample_request(temp: &TempDir) -> ImportPdfRequest {
+        let pdf = temp.path().join("doc.pdf");
+        fs::write(&pdf, b"pdf").unwrap();
+        ImportPdfRequest { path: pdf }
+    }
+
+    #[test]
+    fn successful_import_parses_json() {
+        let temp = TempDir::new().unwrap();
+        let _guard = write_mock_importer(
+            &temp,
+            r#"import json, sys
+print(json.dumps({
+    "title": "Doc",
+    "language": "es",
+    "sections": [
+        {"id": "1", "heading": "Intro", "content": "Hola"}
+    ],
+    "metadata": {"pages": 3},
+    "warnings": ["minor"]
+}))
+"#,
+        );
+        let request = sample_request(&temp);
+        let response = import_pdf(request).unwrap();
+        assert_eq!(response.document.title.as_deref(), Some("Doc"));
+        assert_eq!(response.document.sections.len(), 1);
+        assert_eq!(response.warnings, vec!["minor".to_string()]);
+    }
+
+    #[test]
+    fn importer_error_returns_script_error() {
+        let temp = TempDir::new().unwrap();
+        let _guard = write_mock_importer(
+            &temp,
+            "import sys\nsys.stderr.write('fail')\nsys.exit(1)",
+        );
+        let request = sample_request(&temp);
+        let error = import_pdf(request).unwrap_err();
+        assert_eq!(error.code, ERROR_SCRIPT_FAILED);
+        assert_eq!(error.details.unwrap(), "fail");
+    }
+
+    #[test]
+    fn invalid_json_returns_error() {
+        let temp = TempDir::new().unwrap();
+        let _guard = write_mock_importer(&temp, "print('not json')");
+        let request = sample_request(&temp);
+        let error = import_pdf(request).unwrap_err();
+        assert_eq!(error.code, ERROR_INVALID_JSON);
+    }
+
+    #[test]
+    fn missing_content_is_invalid_response() {
+        let temp = TempDir::new().unwrap();
+        let _guard = write_mock_importer(
+            &temp,
+            r#"import json
+print(json.dumps({"sections": [{}]}))
+"#,
+        );
+        let request = sample_request(&temp);
+        let error = import_pdf(request).unwrap_err();
+        assert_eq!(error.code, ERROR_INVALID_RESPONSE);
+    }
+
+    #[test]
+    fn missing_file_returns_io_error() {
+        let temp = TempDir::new().unwrap();
+        let request = ImportPdfRequest {
+            path: temp.path().join("missing.pdf"),
+        };
+        let error = import_pdf(request).unwrap_err();
+        assert_eq!(error.code, ERROR_IO);
+    }
+}

--- a/src-tauri/src/cmds/mod.rs
+++ b/src-tauri/src/cmds/mod.rs
@@ -1,15 +1,12 @@
-//! Command module stubs for the Tauri backend.
-//!
-//! Each subcommand will bridge the UI with platform capabilities such as
-//! Piper synthesis and document importers. Replace the placeholder
-//! functions with real implementations as the MVP evolves.
+pub mod import_epub;
+pub mod import_pdf;
+pub mod speak;
 
-/// Placeholder module for speech synthesis commands.
-pub mod speak {
-    //! Spawn Piper subprocesses and manage streaming playback here.
-}
+pub use import_epub::import_epub;
+pub use import_pdf::import_pdf;
+pub use speak::speak;
 
-/// Placeholder module for document import commands.
-pub mod import {
-    //! Wire Python helpers for EPUB/PDF extraction here.
-}
+pub use import_epub::ImportEpubRequest;
+pub use import_pdf::ImportPdfRequest;
+pub use speak::SpeakRequest;
+pub use speak::CommandError;

--- a/src-tauri/src/cmds/speak.rs
+++ b/src-tauri/src/cmds/speak.rs
@@ -1,0 +1,314 @@
+use std::{
+    fs,
+    io::Write,
+    path::PathBuf,
+    process::{Command, Stdio},
+    time::Instant,
+};
+
+use log::{error, info, warn};
+use serde::{Deserialize, Serialize};
+use shlex::Shlex;
+use thiserror::Error;
+
+const ERROR_VOICE_NOT_FOUND: &str = "VOICE_NOT_FOUND";
+const ERROR_PROCESS_FAILED: &str = "PROCESS_FAILED";
+const ERROR_IO: &str = "IO_ERROR";
+const ERROR_INTERNAL: &str = "INTERNAL_ERROR";
+
+#[derive(Debug, Error)]
+pub enum CommandFailure {
+    #[error("voice model not found at {0}")]
+    VoiceNotFound(PathBuf),
+    #[error("failed to spawn Piper process: {0}")]
+    SpawnFailure(#[from] std::io::Error),
+    #[error("Piper exited with status {status}: {stderr}")]
+    PiperFailure { status: i32, stderr: String },
+    #[error("{0}")]
+    Other(String),
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct CommandError {
+    pub code: String,
+    pub message: String,
+    pub details: Option<String>,
+}
+
+impl CommandError {
+    pub fn new(code: &str, message: impl Into<String>, details: Option<String>) -> Self {
+        Self {
+            code: code.to_string(),
+            message: message.into(),
+            details,
+        }
+    }
+}
+
+impl From<CommandFailure> for CommandError {
+    fn from(value: CommandFailure) -> Self {
+        match value {
+            CommandFailure::VoiceNotFound(path) => CommandError::new(
+                ERROR_VOICE_NOT_FOUND,
+                format!("Voice model not found: {}", path.display()),
+                None,
+            ),
+            CommandFailure::SpawnFailure(err) => CommandError::new(
+                ERROR_IO,
+                "Failed to launch Piper",
+                Some(err.to_string()),
+            ),
+            CommandFailure::PiperFailure { status, stderr } => CommandError::new(
+                ERROR_PROCESS_FAILED,
+                format!("Piper exited with status {status}"),
+                Some(stderr),
+            ),
+            CommandFailure::Other(message) => {
+                CommandError::new(ERROR_INTERNAL, message, None)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SpeakRequest {
+    pub text: String,
+    pub model_path: PathBuf,
+    pub output_path: PathBuf,
+    #[serde(default)]
+    pub speaker: Option<String>,
+    #[serde(default)]
+    pub length_scale: Option<f32>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct SpeakResponse {
+    pub output_path: PathBuf,
+    pub duration_ms: u128,
+    pub stderr: Option<String>,
+}
+
+trait PiperInvoker {
+    fn invoke(&self, request: &SpeakRequest) -> Result<SpeakResponse, CommandFailure>;
+}
+
+struct DefaultPiperInvoker;
+
+impl DefaultPiperInvoker {
+    fn build_command(request: &SpeakRequest) -> Result<Command, CommandFailure> {
+        if !request.model_path.exists() {
+            return Err(CommandFailure::VoiceNotFound(request.model_path.clone()));
+        }
+
+        if let Some(parent) = request
+            .output_path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent).map_err(|err| {
+                CommandFailure::Other(format!(
+                    "Unable to create output directory {}: {err}",
+                    parent.display()
+                ))
+            })?;
+        }
+
+        if let Some(raw_command) = std::env::var_os("READER_PIPER_COMMAND") {
+            let raw_command = raw_command.to_string_lossy().into_owned();
+            let mut shlex = Shlex::new(&raw_command);
+            let mut parts: Vec<String> = shlex.collect();
+            if parts.is_empty() {
+                return Err(CommandFailure::Other(
+                    "READER_PIPER_COMMAND is empty".to_string(),
+                ));
+            }
+            let program = parts.remove(0);
+            let mut command = Command::new(program);
+            for part in parts {
+                command.arg(part);
+            }
+            Ok(command)
+        } else if cfg!(target_os = "windows") {
+            Ok(Command::new("runtime/piper/piper.exe"))
+        } else {
+            let mut command = Command::new("python");
+            command.args(["-m", "piper"]);
+            Ok(command)
+        }
+    }
+
+    fn command_arguments(command: &mut Command, request: &SpeakRequest) {
+        command.arg("--model");
+        command.arg(&request.model_path);
+        command.arg("--output_file");
+        command.arg(&request.output_path);
+        if let Some(speaker) = &request.speaker {
+            command.arg("--speaker");
+            command.arg(speaker);
+        }
+        if let Some(scale) = request.length_scale {
+            command.arg("--length_scale");
+            command.arg(scale.to_string());
+        }
+    }
+}
+
+impl PiperInvoker for DefaultPiperInvoker {
+    fn invoke(&self, request: &SpeakRequest) -> Result<SpeakResponse, CommandFailure> {
+        let start = Instant::now();
+        let mut command = Self::build_command(request)?;
+        Self::command_arguments(&mut command, request);
+        let mut child = command
+            .stdin(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(CommandFailure::SpawnFailure)?;
+        {
+            let stdin = child.stdin.as_mut().ok_or_else(|| {
+                CommandFailure::Other("Failed to access Piper stdin".into())
+            })?;
+            stdin
+                .write_all(request.text.as_bytes())
+                .map_err(|err| CommandFailure::Other(err.to_string()))?;
+        }
+        let output = child
+            .wait_with_output()
+            .map_err(|err| CommandFailure::Other(err.to_string()))?;
+        let duration_ms = start.elapsed().as_millis();
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+        if !output.status.success() {
+            let code = output.status.code().unwrap_or_default();
+            error!(
+                "Piper command exited with status {code}: {}",
+                stderr
+            );
+            return Err(CommandFailure::PiperFailure {
+                status: code,
+                stderr,
+            });
+        }
+
+        if !request.output_path.exists() {
+            warn!(
+                "Piper succeeded but the expected output {:?} was not created",
+                request.output_path
+            );
+        }
+
+        Ok(SpeakResponse {
+            output_path: request.output_path.clone(),
+            duration_ms,
+            stderr: if stderr.is_empty() { None } else { Some(stderr) },
+        })
+    }
+}
+
+pub fn speak(request: SpeakRequest) -> Result<SpeakResponse, CommandError> {
+    info!(
+        "Invoking Piper for model {} writing to {}",
+        request.model_path.display(),
+        request.output_path.display()
+    );
+
+    DefaultPiperInvoker
+        .invoke(&request)
+        .map_err(|err| {
+            error!("Speak command failed: {err}");
+            CommandError::from(err)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::TempDir;
+
+    struct EnvVarGuard {
+        key: &'static str,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: String) -> Self {
+            std::env::set_var(key, value);
+            Self { key }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            std::env::remove_var(self.key);
+        }
+    }
+
+    fn write_mock_piper_script(temp: &TempDir, content: &str) -> EnvVarGuard {
+        let script_path = temp.path().join("mock_piper.py");
+        fs::write(&script_path, content).unwrap();
+        EnvVarGuard::set(
+            "READER_PIPER_COMMAND",
+            format!("python3 {}", script_path.display()),
+        )
+    }
+
+    fn make_request(temp: &TempDir, model_exists: bool) -> SpeakRequest {
+        let model_path = temp.path().join("voice.onnx");
+        if model_exists {
+            fs::write(&model_path, b"voice").unwrap();
+        }
+        let output_path = temp.path().join("output.wav");
+        SpeakRequest {
+            text: "hola".into(),
+            model_path,
+            output_path,
+            speaker: None,
+            length_scale: None,
+        }
+    }
+
+    #[test]
+    fn speak_success_creates_audio() {
+        let temp = TempDir::new().unwrap();
+        let _guard = write_mock_piper_script(&temp, 
+            r#"import argparse
+import sys
+parser = argparse.ArgumentParser()
+parser.add_argument('--model')
+parser.add_argument('--output_file')
+args = parser.parse_args()
+text = sys.stdin.read()
+with open(args.output_file, 'w', encoding='utf-8') as f:
+    f.write('WAV:' + text)
+"#,
+        );
+        let request = make_request(&temp, true);
+        let response = speak(request).unwrap();
+        assert!(response.duration_ms > 0);
+        let output = fs::read_to_string(temp.path().join("output.wav")).unwrap();
+        assert_eq!(output, "WAV:hola");
+    }
+
+    #[test]
+    fn speak_missing_voice_returns_error() {
+        let temp = TempDir::new().unwrap();
+        let _guard = write_mock_piper_script(&temp, "import sys; sys.exit(0)");
+        let request = make_request(&temp, false);
+        let error = speak(request).unwrap_err();
+        assert_eq!(error.code, ERROR_VOICE_NOT_FOUND);
+    }
+
+    #[test]
+    fn speak_process_failure_returns_error() {
+        let temp = TempDir::new().unwrap();
+        let _guard = write_mock_piper_script(
+            &temp,
+            r#"import sys
+sys.stderr.write('boom')
+sys.exit(2)
+"#,
+        );
+        let request = make_request(&temp, true);
+        let error = speak(request).unwrap_err();
+        assert_eq!(error.code, ERROR_PROCESS_FAILED);
+        assert_eq!(error.details.unwrap(), "boom");
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,62 @@
+use std::{fs, path::PathBuf};
+
+use log::{error, info};
+mod cmds;
+
+use cmds::{import_epub, import_pdf, speak};
+
+fn init_logging() {
+    let logs_dir = PathBuf::from("logs");
+    if let Err(err) = fs::create_dir_all(&logs_dir) {
+        eprintln!("Failed to create log directory {logs_dir:?}: {err}");
+    }
+
+    if let Err(err) = flexi_logger::Logger::try_with_env_or_str("info")
+        .and_then(|logger| {
+            logger
+                .log_to_file(
+                    flexi_logger::FileSpec::default()
+                        .directory(&logs_dir)
+                        .basename("reader")
+                        .suffix("log")
+                        .suppress_timestamp(),
+                )
+                .rotate(
+                    flexi_logger::Criterion::Size(5_000_000),
+                    flexi_logger::Naming::Numbers,
+                    flexi_logger::Cleanup::KeepLogFiles(5),
+                )
+                .duplicate_to_stderr(flexi_logger::Duplicate::Info)
+                .start()
+        })
+    {
+        eprintln!("Failed to initialise logger: {err}");
+    }
+}
+
+fn main() {
+    init_logging();
+    info!("Starting Reader Tauri backend");
+
+    if let Err(err) = tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![speak, import_pdf, import_epub])
+        .run(tauri::generate_context!())
+    {
+        error!("Tauri runtime error: {err:?}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logger_creates_directory() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(temp_dir.path()).unwrap();
+        init_logging();
+        assert!(temp_dir.path().join("logs").exists());
+        std::env::set_current_dir(original_dir).unwrap();
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,15 @@
+{
+  "package": {
+    "productName": "Reader",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "windows": [
+      {
+        "title": "Reader",
+        "width": 1024,
+        "height": 768
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a Tauri backend crate with logging bootstrap and command wiring
- implement Piper speech synthesis command with structured errors and tests
- add PDF/EPUB import commands that parse script JSON results and cover error paths

## Testing
- `cargo test` *(fails: unable to download crates.io index due to 403 CONNECT tunnel error)*


------
https://chatgpt.com/codex/tasks/task_e_68de558196188328917f230626d6d255