### PR TITLE
feat: bootstrap reader ui

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es" class="h-full">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Reader</title>
+  </head>
+  <body class="h-full bg-background text-foreground">
+    <div id="root" class="h-full"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "reader-ui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^2.0.0",
+    "clsx": "^2.1.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zustand": "^4.5.5"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@vitejs/plugin-react": "^4.2.1",
+    "@types/node": "^20.11.20",
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0",
+    "vitest": "^1.5.0"
+  }
+}

--- a/ui/postcss.config.cjs
+++ b/ui/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import Reader from './pages/Reader';
+import { usePlayerStore } from './store/playerStore';
+
+const App = () => {
+  const theme = usePlayerStore((state) => state.preferences.theme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [theme]);
+
+  return <Reader />;
+};
+
+export default App;

--- a/ui/src/components/Controls.tsx
+++ b/ui/src/components/Controls.tsx
@@ -1,0 +1,94 @@
+interface ControlsProps {
+  isPlaying: boolean;
+  onPlayPause: () => void;
+  onNext: () => void;
+  rate: number;
+  pitch: number;
+  volume: number;
+  onRateChange: (value: number) => void;
+  onPitchChange: (value: number) => void;
+  onVolumeChange: (value: number) => void;
+}
+
+const sliderClass =
+  'w-full accent-primary focus-ring cursor-pointer';
+
+const Controls = ({
+  isPlaying,
+  onPlayPause,
+  onNext,
+  rate,
+  pitch,
+  volume,
+  onRateChange,
+  onPitchChange,
+  onVolumeChange
+}: ControlsProps) => (
+  <section className="space-y-6 rounded-xl border border-muted/40 bg-background/60 p-4 shadow-sm">
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={onPlayPause}
+        className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white focus-ring"
+      >
+        {isPlaying ? 'Pausa' : 'Reproducir'}
+      </button>
+      <button
+        type="button"
+        onClick={onNext}
+        className="rounded-md border border-muted/40 px-4 py-2 text-sm font-medium text-foreground focus-ring"
+      >
+        Siguiente
+      </button>
+    </div>
+
+    <div className="grid gap-4 sm:grid-cols-3">
+      <label className="flex flex-col gap-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted">Velocidad</span>
+        <input
+          aria-label="Velocidad"
+          type="range"
+          min="0.5"
+          max="2"
+          step="0.1"
+          value={rate}
+          onChange={(event) => onRateChange(Number(event.target.value))}
+          className={sliderClass}
+        />
+        <span className="text-xs text-muted">{rate.toFixed(2)}x</span>
+      </label>
+
+      <label className="flex flex-col gap-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted">Tono</span>
+        <input
+          aria-label="Tono"
+          type="range"
+          min="0.5"
+          max="2"
+          step="0.1"
+          value={pitch}
+          onChange={(event) => onPitchChange(Number(event.target.value))}
+          className={sliderClass}
+        />
+        <span className="text-xs text-muted">{pitch.toFixed(2)}x</span>
+      </label>
+
+      <label className="flex flex-col gap-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted">Volumen</span>
+        <input
+          aria-label="Volumen"
+          type="range"
+          min="0"
+          max="1"
+          step="0.05"
+          value={volume}
+          onChange={(event) => onVolumeChange(Number(event.target.value))}
+          className={sliderClass}
+        />
+        <span className="text-xs text-muted">{Math.round(volume * 100)}%</span>
+      </label>
+    </div>
+  </section>
+);
+
+export default Controls;

--- a/ui/src/components/QueueList.tsx
+++ b/ui/src/components/QueueList.tsx
@@ -1,0 +1,32 @@
+import { clsx } from 'clsx';
+
+interface QueueListProps {
+  items: string[];
+  currentIndex: number;
+  onSelect: (index: number) => void;
+}
+
+const QueueList = ({ items, currentIndex, onSelect }: QueueListProps) => (
+  <ol className="space-y-2" aria-live="polite">
+    {items.map((paragraph, index) => (
+      <li key={index}>
+        <button
+          type="button"
+          className={clsx(
+            'w-full rounded-lg border px-4 py-3 text-left text-sm transition focus-ring',
+            index === currentIndex
+              ? 'border-primary bg-primary/10 text-primary'
+              : 'border-transparent bg-muted/20 text-foreground hover:border-muted/60 hover:bg-muted/30'
+          )}
+          onClick={() => onSelect(index)}
+        >
+          <span className="block max-h-24 overflow-y-auto whitespace-pre-wrap">
+            {paragraph.trim() || 'Párrafo vacío'}
+          </span>
+        </button>
+      </li>
+    ))}
+  </ol>
+);
+
+export default QueueList;

--- a/ui/src/components/VoiceSelector.tsx
+++ b/ui/src/components/VoiceSelector.tsx
@@ -1,0 +1,27 @@
+import type { ChangeEventHandler } from 'react';
+import type { VoicePreference } from '../store/playerStore';
+
+interface VoiceSelectorProps {
+  voices: VoicePreference[];
+  value: string;
+  onChange: ChangeEventHandler<HTMLSelectElement>;
+}
+
+const VoiceSelector = ({ voices, value, onChange }: VoiceSelectorProps) => (
+  <label className="flex flex-col gap-2">
+    <span className="text-sm font-medium text-muted">Voz</span>
+    <select
+      className="rounded-md border border-muted/50 bg-transparent px-3 py-2 text-sm focus-ring"
+      value={value}
+      onChange={onChange}
+    >
+      {voices.map((voice) => (
+        <option key={voice.id} value={voice.id}>
+          {voice.label}
+        </option>
+      ))}
+    </select>
+  </label>
+);
+
+export default VoiceSelector;

--- a/ui/src/components/__tests__/Controls.test.tsx
+++ b/ui/src/components/__tests__/Controls.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import Controls from '../Controls';
+
+describe('Controls component', () => {
+  const setup = () => {
+    const onPlayPause = vi.fn();
+    const onNext = vi.fn();
+    const onRateChange = vi.fn();
+    const onPitchChange = vi.fn();
+    const onVolumeChange = vi.fn();
+
+    render(
+      <Controls
+        isPlaying={false}
+        onPlayPause={onPlayPause}
+        onNext={onNext}
+        rate={1}
+        pitch={1}
+        volume={1}
+        onRateChange={onRateChange}
+        onPitchChange={onPitchChange}
+        onVolumeChange={onVolumeChange}
+      />
+    );
+
+    return { onPlayPause, onNext, onRateChange, onPitchChange, onVolumeChange };
+  };
+
+  it('triggers play and next callbacks', () => {
+    const callbacks = setup();
+
+    fireEvent.click(screen.getByRole('button', { name: /reproducir/i }));
+    fireEvent.click(screen.getByRole('button', { name: /siguiente/i }));
+
+    expect(callbacks.onPlayPause).toHaveBeenCalledTimes(1);
+    expect(callbacks.onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports slider changes', () => {
+    const callbacks = setup();
+
+    fireEvent.change(screen.getByLabelText(/velocidad/i), { target: { value: '1.5' } });
+    fireEvent.change(screen.getByLabelText(/tono/i), { target: { value: '1.2' } });
+    fireEvent.change(screen.getByLabelText(/volumen/i), { target: { value: '0.6' } });
+
+    expect(callbacks.onRateChange).toHaveBeenCalledWith(1.5);
+    expect(callbacks.onPitchChange).toHaveBeenCalledWith(1.2);
+    expect(callbacks.onVolumeChange).toHaveBeenCalledWith(0.6);
+  });
+});

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,0 +1,33 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: light;
+    --color-background: 255 255 255;
+    --color-foreground: 15 23 42;
+    --color-primary: 79 70 229;
+    --color-muted: 148 163 184;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    line-height: 1.5;
+  }
+
+  .dark {
+    color-scheme: dark;
+    --color-background: 15 23 42;
+    --color-foreground: 241 245 249;
+    --color-primary: 99 102 241;
+    --color-muted: 100 116 139;
+  }
+
+  body {
+    min-height: 100vh;
+  }
+}
+
+@layer utilities {
+  .focus-ring {
+    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background;
+  }
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/ui/src/pages/Reader.tsx
+++ b/ui/src/pages/Reader.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useMemo, useState } from 'react';
+import Controls from '../components/Controls';
+import QueueList from '../components/QueueList';
+import VoiceSelector from '../components/VoiceSelector';
+import { usePlayerStore } from '../store/playerStore';
+
+const parseParagraphs = (content: string) =>
+  content
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0);
+
+const Reader = () => {
+  const queue = usePlayerStore((state) => state.queue);
+  const currentIndex = usePlayerStore((state) => state.currentIndex);
+  const isPlaying = usePlayerStore((state) => state.isPlaying);
+  const preferences = usePlayerStore((state) => state.preferences);
+  const availableVoices = usePlayerStore((state) => state.availableVoices);
+  const setQueue = usePlayerStore((state) => state.setQueue);
+  const setVoice = usePlayerStore((state) => state.setVoice);
+  const setRate = usePlayerStore((state) => state.setRate);
+  const setPitch = usePlayerStore((state) => state.setPitch);
+  const setVolume = usePlayerStore((state) => state.setVolume);
+  const playFrom = usePlayerStore((state) => state.playFrom);
+  const playNext = usePlayerStore((state) => state.playNext);
+  const togglePlayPause = usePlayerStore((state) => state.togglePlayPause);
+  const importDocument = usePlayerStore((state) => state.importDocument);
+  const toggleTheme = usePlayerStore((state) => state.toggleTheme);
+  const loadVoices = usePlayerStore((state) => state.loadVoices);
+  const [editorValue, setEditorValue] = useState('');
+  const [importing, setImporting] = useState(false);
+
+  useEffect(() => {
+    setEditorValue(queue.join('\n\n'));
+  }, [queue]);
+
+  useEffect(() => {
+    void loadVoices();
+  }, [loadVoices]);
+
+  const highlightedParagraphs = useMemo(() => queue, [queue]);
+
+  const handleApplyText = () => {
+    const paragraphs = parseParagraphs(editorValue);
+    setQueue(paragraphs);
+  };
+
+  const handlePlayPause = async () => {
+    if (!isPlaying) {
+      if (queue.length === 0) {
+        const paragraphs = parseParagraphs(editorValue);
+        if (paragraphs.length === 0) {
+          return;
+        }
+        setQueue(paragraphs);
+        await playFrom(0);
+        return;
+      }
+      await playFrom(currentIndex);
+    } else {
+      await togglePlayPause();
+    }
+  };
+
+  const handleNext = async () => {
+    if (queue.length === 0) {
+      return;
+    }
+    await playNext();
+  };
+
+  const handleImport = async (command: string) => {
+    setImporting(true);
+    try {
+      await importDocument(command);
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-background px-4 py-8 text-foreground">
+      <div className="mx-auto flex max-w-6xl flex-col gap-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold">Lector asistido</h1>
+            <p className="text-sm text-muted">
+              Prepara tus párrafos, organízalos en la cola y controla la reproducción de Piper desde Tauri.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={toggleTheme}
+            className="self-start rounded-md border border-muted/40 px-3 py-2 text-sm font-medium focus-ring"
+            aria-pressed={preferences.theme === 'dark'}
+          >
+            {preferences.theme === 'dark' ? 'Tema claro' : 'Tema oscuro'}
+          </button>
+        </header>
+
+        <section className="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+          <div className="space-y-6">
+            <div className="rounded-xl border border-muted/40 bg-background/70 p-4 shadow-sm">
+              <div className="flex items-center justify-between gap-4">
+                <h2 className="text-lg font-semibold">Editor de párrafos</h2>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleImport('import_epub')}
+                    className="rounded-md border border-muted/40 px-3 py-2 text-xs font-medium focus-ring"
+                    disabled={importing}
+                  >
+                    Importar EPUB
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleImport('import_pdf')}
+                    className="rounded-md border border-muted/40 px-3 py-2 text-xs font-medium focus-ring"
+                    disabled={importing}
+                  >
+                    Importar PDF
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleImport('import_text')}
+                    className="rounded-md border border-muted/40 px-3 py-2 text-xs font-medium focus-ring"
+                    disabled={importing}
+                  >
+                    Importar texto
+                  </button>
+                </div>
+              </div>
+              <textarea
+                className="mt-4 h-64 w-full resize-y rounded-lg border border-muted/40 bg-background/80 p-4 text-sm leading-relaxed focus-ring"
+                placeholder="Escribe o pega tus párrafos. Se separarán por dobles saltos de línea."
+                value={editorValue}
+                onChange={(event) => setEditorValue(event.target.value)}
+              />
+              <div className="mt-4 flex justify-end">
+                <button
+                  type="button"
+                  onClick={handleApplyText}
+                  className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white focus-ring"
+                >
+                  Actualizar cola
+                </button>
+              </div>
+            </div>
+
+            <section className="space-y-4">
+              <h2 className="text-lg font-semibold">Reproductor</h2>
+              <VoiceSelector
+                voices={availableVoices}
+                value={preferences.voice}
+                onChange={(event) => setVoice(event.target.value)}
+              />
+              <Controls
+                isPlaying={isPlaying}
+                onPlayPause={handlePlayPause}
+                onNext={handleNext}
+                rate={preferences.rate}
+                pitch={preferences.pitch}
+                volume={preferences.volume}
+                onRateChange={setRate}
+                onPitchChange={setPitch}
+                onVolumeChange={setVolume}
+              />
+            </section>
+          </div>
+
+          <aside className="space-y-6">
+            <section className="rounded-xl border border-muted/40 bg-background/70 p-4 shadow-sm">
+              <h2 className="text-lg font-semibold">Cola de lectura</h2>
+              {queue.length === 0 ? (
+                <p className="mt-4 text-sm text-muted">Añade contenido para comenzar a escuchar.</p>
+              ) : (
+                <QueueList items={queue} currentIndex={currentIndex} onSelect={(index) => void playFrom(index)} />
+              )}
+            </section>
+
+            <section className="rounded-xl border border-muted/40 bg-background/70 p-4 shadow-sm">
+              <h2 className="text-lg font-semibold">Vista previa</h2>
+              <div className="mt-4 space-y-4">
+                {highlightedParagraphs.map((paragraph, index) => (
+                  <article
+                    key={index}
+                    className={`rounded-lg border p-4 text-sm leading-relaxed ${
+                      index === currentIndex
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-transparent bg-muted/10 text-foreground'
+                    }`}
+                  >
+                    {paragraph}
+                  </article>
+                ))}
+              </div>
+            </section>
+          </aside>
+        </section>
+      </div>
+    </main>
+  );
+};
+
+export default Reader;

--- a/ui/src/store/playerStore.test.ts
+++ b/ui/src/store/playerStore.test.ts
@@ -1,0 +1,87 @@
+import { act } from '@testing-library/react';
+import type { Mock } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/tauri';
+import {
+  usePlayerStore,
+  defaultPreferences,
+  defaultVoices
+} from './playerStore';
+
+vi.mock('@tauri-apps/api/tauri', () => ({
+  invoke: vi.fn()
+}));
+
+const mockedInvoke = invoke as unknown as Mock;
+
+beforeEach(() => {
+  window.localStorage.clear();
+  mockedInvoke.mockReset();
+  usePlayerStore.setState({
+    queue: [],
+    currentIndex: 0,
+    isPlaying: false,
+    preferences: { ...defaultPreferences },
+    availableVoices: defaultVoices
+  });
+});
+
+afterEach(() => {
+  usePlayerStore.setState({ queue: [], isPlaying: false, currentIndex: 0 });
+});
+
+const resolveInvoke = () => mockedInvoke.mockResolvedValueOnce(undefined);
+
+describe('playerStore', () => {
+  it('filters paragraphs when setting queue', () => {
+    usePlayerStore.getState().setQueue(['Hola', '', ' Mundo ']);
+    const { queue, currentIndex } = usePlayerStore.getState();
+
+    expect(queue).toEqual(['Hola', 'Mundo']);
+    expect(currentIndex).toBe(0);
+  });
+
+  it('persists slider preferences to localStorage', async () => {
+    await act(async () => {
+      usePlayerStore.getState().setRate(1.8);
+      usePlayerStore.getState().setPitch(0.4);
+      usePlayerStore.getState().setVolume(0.25);
+    });
+
+    const persisted = window.localStorage.getItem('reader-player-preferences');
+    expect(persisted).toMatch(/"rate":1.8/);
+    expect(persisted).toMatch(/"volume":0.25/);
+    expect(persisted).toMatch(/"pitch":0.5/);
+  });
+
+  it('invokes tauri speak command when playing from index', async () => {
+    usePlayerStore.setState({ queue: ['Uno', 'Dos'] });
+    resolveInvoke();
+
+    await act(async () => {
+      await usePlayerStore.getState().playFrom(1);
+    });
+
+    expect(mockedInvoke).toHaveBeenCalledWith(
+      'speak',
+      expect.objectContaining({
+        text: 'Dos',
+        options: expect.objectContaining({ voice: 'default' })
+      })
+    );
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+
+  it('stops audio when toggling from playing state', async () => {
+    usePlayerStore.setState({ isPlaying: true });
+    resolveInvoke();
+
+    await act(async () => {
+      await usePlayerStore.getState().togglePlayPause();
+    });
+
+    expect(mockedInvoke).toHaveBeenCalledWith('stop_audio');
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+});

--- a/ui/src/store/playerStore.ts
+++ b/ui/src/store/playerStore.ts
@@ -1,0 +1,178 @@
+import { invoke } from '@tauri-apps/api/tauri';
+import { create } from 'zustand';
+import { persist, createJSONStorage, StateStorage } from 'zustand/middleware';
+
+export type VoicePreference = {
+  id: string;
+  label: string;
+};
+
+export type ThemeMode = 'light' | 'dark';
+
+export interface PlayerPreferences {
+  voice: string;
+  rate: number;
+  pitch: number;
+  volume: number;
+  theme: ThemeMode;
+}
+
+export const defaultPreferences: PlayerPreferences = {
+  voice: 'default',
+  rate: 1,
+  pitch: 1,
+  volume: 1,
+  theme: 'light'
+};
+
+export const defaultVoices: VoicePreference[] = [
+  { id: 'default', label: 'Predeterminada' },
+  { id: 'es-ES-carlfm-x-low', label: 'es-ES - CarlFM' }
+];
+
+export interface PlayerState {
+  queue: string[];
+  currentIndex: number;
+  isPlaying: boolean;
+  preferences: PlayerPreferences;
+  availableVoices: VoicePreference[];
+  setQueue: (paragraphs: string[]) => void;
+  enqueue: (paragraph: string | string[]) => void;
+  setCurrentIndex: (index: number) => void;
+  setVoice: (voice: string) => void;
+  setRate: (value: number) => void;
+  setPitch: (value: number) => void;
+  setVolume: (value: number) => void;
+  toggleTheme: () => void;
+  loadVoices: () => Promise<void>;
+  playFrom: (index: number) => Promise<void>;
+  togglePlayPause: () => Promise<void>;
+  playNext: () => Promise<void>;
+  importDocument: (command: string, args?: Record<string, unknown>) => Promise<void>;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const noopStorage: StateStorage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined
+};
+
+const storage =
+  typeof window !== 'undefined'
+    ? createJSONStorage(() => window.localStorage)
+    : createJSONStorage(() => noopStorage);
+
+export const usePlayerStore = create<PlayerState>()(
+  persist(
+    (set, get) => ({
+      queue: [],
+      currentIndex: 0,
+      isPlaying: false,
+      preferences: { ...defaultPreferences },
+      availableVoices: defaultVoices,
+      setQueue: (paragraphs) => {
+        set({ queue: paragraphs.filter((paragraph) => paragraph.trim().length > 0), currentIndex: 0 });
+      },
+      enqueue: (paragraph) => {
+        const toAdd = Array.isArray(paragraph) ? paragraph : [paragraph];
+        set((state) => ({ queue: [...state.queue, ...toAdd.filter((item) => item.trim().length > 0)] }));
+      },
+      setCurrentIndex: (index) => {
+        set({ currentIndex: clamp(index, 0, Math.max(get().queue.length - 1, 0)) });
+      },
+      setVoice: (voice) => {
+        set((state) => ({ preferences: { ...state.preferences, voice } }));
+      },
+      setRate: (value) => {
+        set((state) => ({ preferences: { ...state.preferences, rate: Number(clamp(value, 0.5, 2).toFixed(2)) } }));
+      },
+      setPitch: (value) => {
+        set((state) => ({ preferences: { ...state.preferences, pitch: Number(clamp(value, 0.5, 2).toFixed(2)) } }));
+      },
+      setVolume: (value) => {
+        set((state) => ({ preferences: { ...state.preferences, volume: Number(clamp(value, 0, 1).toFixed(2)) } }));
+      },
+      toggleTheme: () => {
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            theme: state.preferences.theme === 'light' ? 'dark' : 'light'
+          }
+        }));
+      },
+      loadVoices: async () => {
+        try {
+          const voices = await invoke<VoicePreference[]>('list_voices');
+          if (Array.isArray(voices) && voices.length > 0) {
+            set({ availableVoices: voices });
+          }
+        } catch (error) {
+          console.warn('No se pudieron cargar las voces desde Tauri', error);
+        }
+      },
+      playFrom: async (index) => {
+        const state = get();
+        const paragraph = state.queue[index];
+        if (!paragraph) {
+          return;
+        }
+        set({ currentIndex: index, isPlaying: true });
+        try {
+          await invoke('speak', {
+            text: paragraph,
+            options: {
+              voice: state.preferences.voice,
+              rate: state.preferences.rate,
+              pitch: state.preferences.pitch,
+              volume: state.preferences.volume
+            }
+          });
+        } catch (error) {
+          console.error('No se pudo reproducir el párrafo', error);
+          set({ isPlaying: false });
+        }
+      },
+      togglePlayPause: async () => {
+        const { isPlaying } = get();
+        try {
+          if (isPlaying) {
+            await invoke('stop_audio');
+            set({ isPlaying: false });
+          } else {
+            await invoke('play_audio');
+            set({ isPlaying: true });
+          }
+        } catch (error) {
+          console.error('Error al alternar la reproducción', error);
+        }
+      },
+      playNext: async () => {
+        const { currentIndex, queue } = get();
+        const nextIndex = currentIndex + 1;
+        if (nextIndex < queue.length) {
+          await get().playFrom(nextIndex);
+        } else {
+          await invoke('stop_audio');
+          set({ isPlaying: false });
+        }
+      },
+      importDocument: async (command, args = {}) => {
+        try {
+          const paragraphs = await invoke<string[]>(command, args);
+          if (Array.isArray(paragraphs)) {
+            get().setQueue(paragraphs);
+          }
+        } catch (error) {
+          console.error('Error al importar documento', error);
+        }
+      }
+    }),
+    {
+      name: 'reader-player-preferences',
+      partialize: (state) => ({ preferences: state.preferences }),
+      storage
+    }
+  )
+);

--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: 'rgb(var(--color-background) / <alpha-value>)',
+        foreground: 'rgb(var(--color-foreground) / <alpha-value>)',
+        primary: 'rgb(var(--color-primary) / <alpha-value>)',
+        muted: 'rgb(var(--color-muted) / <alpha-value>)'
+      }
+    }
+  },
+  plugins: []
+} satisfies Config;

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["src", "vite.config.ts", "vitest.config.ts"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/ui/tsconfig.node.json
+++ b/ui/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "vitest.config.ts"]
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    globals: true
+  }
+});

--- a/ui/vitest.setup.ts
+++ b/ui/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript frontend with Tailwind CSS and testing harness
- build the Reader page with queue management, playback controls, voice selector, theming, and Tauri command wiring
- add a persisted Zustand player store plus component and state tests

## Testing
- npm test -- --run *(fails: vitest not found without installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68de558898a0832881919d3a7c961292