### PR TITLE
Add Tauri voice discovery command

### DIFF
--- a/src-tauri/src/cmds/mod.rs
+++ b/src-tauri/src/cmds/mod.rs
@@ -1,12 +1,15 @@
 pub mod import_epub;
 pub mod import_pdf;
 pub mod speak;
+pub mod voices;
 
 pub use import_epub::import_epub;
 pub use import_pdf::import_pdf;
 pub use speak::speak;
+pub use voices::list_voices;
+pub use voices::VoicePreference;
 
 pub use import_epub::ImportEpubRequest;
 pub use import_pdf::ImportPdfRequest;
-pub use speak::SpeakRequest;
 pub use speak::CommandError;
+pub use speak::SpeakRequest;

--- a/src-tauri/src/cmds/voices.rs
+++ b/src-tauri/src/cmds/voices.rs
@@ -1,0 +1,343 @@
+use std::{
+    collections::HashSet,
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use log::{debug, warn};
+use serde::{Deserialize, Serialize};
+
+use super::speak::CommandError;
+
+const ERROR_DISCOVERY_IO: &str = "VOICES_IO_ERROR";
+const ERROR_METADATA_INVALID: &str = "VOICES_METADATA_INVALID";
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct VoicePreference {
+    pub id: String,
+    pub label: String,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+struct VoiceMetadata {
+    language: Option<LanguageMetadata>,
+    dataset: Option<String>,
+    audio: Option<AudioMetadata>,
+    reader: Option<ReaderMetadata>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+struct LanguageMetadata {
+    code: Option<String>,
+    name_native: Option<String>,
+    name_english: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+struct AudioMetadata {
+    quality: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+struct ReaderMetadata {
+    label: Option<String>,
+}
+
+fn voices_root() -> PathBuf {
+    PathBuf::from("assets/voices")
+}
+
+fn read_directory(path: &Path) -> Result<Option<fs::ReadDir>, CommandError> {
+    match fs::read_dir(path) {
+        Ok(read_dir) => Ok(Some(read_dir)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(CommandError::new(
+            ERROR_DISCOVERY_IO,
+            format!("Failed to read voices directory at {}", path.display()),
+            Some(err.to_string()),
+        )),
+    }
+}
+
+fn is_voice_metadata(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("json"))
+        .unwrap_or(false)
+        && path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.ends_with(".onnx.json"))
+            .unwrap_or(false)
+}
+
+fn is_voice_model(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("onnx"))
+        .unwrap_or(false)
+}
+
+fn metadata_path_for_model(path: &Path) -> PathBuf {
+    let mut os_string: OsString = path.as_os_str().to_os_string();
+    os_string.push(".json");
+    PathBuf::from(os_string)
+}
+
+fn voice_basename(path: &Path) -> Option<String> {
+    let file_name = path.file_name()?.to_str()?;
+    if let Some(name) = file_name.strip_suffix(".onnx.json") {
+        return Some(name.to_string());
+    }
+    if let Some(name) = file_name.strip_suffix(".onnx") {
+        return Some(name.to_string());
+    }
+    None
+}
+
+fn voice_id_from_basename(basename: &str) -> String {
+    basename.replace('_', "-")
+}
+
+fn read_metadata(path: &Path) -> Result<VoiceMetadata, CommandError> {
+    let content = fs::read_to_string(path).map_err(|err| {
+        CommandError::new(
+            ERROR_DISCOVERY_IO,
+            format!("Failed to read metadata at {}", path.display()),
+            Some(err.to_string()),
+        )
+    })?;
+
+    serde_json::from_str(&content).map_err(|err| {
+        CommandError::new(
+            ERROR_METADATA_INVALID,
+            format!("Invalid metadata for voice at {}", path.display()),
+            Some(err.to_string()),
+        )
+    })
+}
+
+fn format_language_label(metadata: &VoiceMetadata) -> Option<String> {
+    metadata.language.as_ref().map(|language| {
+        let code = language.code.as_deref().map(|code| code.replace('_', "-"));
+        let name = language
+            .name_native
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| language.name_english.as_ref());
+
+        match (code, name) {
+            (Some(code), Some(name)) => format!("{code} - {name}"),
+            (Some(code), None) => code,
+            (None, Some(name)) => name.to_string(),
+            (None, None) => String::new(),
+        }
+    })
+}
+
+fn title_case(value: &str) -> String {
+    value
+        .split(['-', '_', ' '])
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            if part.chars().all(|c| c.is_ascii_uppercase()) {
+                part.to_string()
+            } else {
+                let mut chars = part.chars();
+                match chars.next() {
+                    Some(first) => {
+                        format!("{}{}", first.to_uppercase(), chars.as_str().to_lowercase())
+                    }
+                    None => String::new(),
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn build_label(basename: &str, metadata: Option<&VoiceMetadata>) -> String {
+    if let Some(metadata) = metadata {
+        if let Some(label) = metadata
+            .reader
+            .as_ref()
+            .and_then(|reader| reader.label.as_ref())
+            .filter(|label| !label.trim().is_empty())
+        {
+            return label.trim().to_string();
+        }
+
+        let mut parts = Vec::new();
+        if let Some(language_label) =
+            format_language_label(metadata).filter(|value| !value.trim().is_empty())
+        {
+            parts.push(language_label);
+        }
+
+        if let Some(dataset) = metadata
+            .dataset
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            parts.push(title_case(dataset));
+        }
+
+        if let Some(quality) = metadata
+            .audio
+            .as_ref()
+            .and_then(|audio| audio.quality.as_ref())
+            .filter(|value| !value.trim().is_empty())
+        {
+            parts.push(title_case(quality));
+        }
+
+        if !parts.is_empty() {
+            return parts.join(" - ");
+        }
+    }
+
+    title_case(&basename.replace('_', " "))
+}
+
+fn register_voice(
+    voices: &mut Vec<VoicePreference>,
+    seen: &mut HashSet<String>,
+    basename: String,
+    metadata: Option<VoiceMetadata>,
+) {
+    let id = voice_id_from_basename(&basename);
+    if seen.contains(&id) {
+        debug!("Skipping duplicate voice id {id}");
+        return;
+    }
+    let label = build_label(&basename, metadata.as_ref());
+    voices.push(VoicePreference {
+        id: id.clone(),
+        label,
+    });
+    seen.insert(id);
+}
+
+fn collect_voices_from(dir: &Path, voices: &mut Vec<VoicePreference>) -> Result<(), CommandError> {
+    let mut seen = HashSet::new();
+    collect_voices_recursive(dir, voices, &mut seen)
+}
+
+fn collect_voices_recursive(
+    dir: &Path,
+    voices: &mut Vec<VoicePreference>,
+    seen: &mut HashSet<String>,
+) -> Result<(), CommandError> {
+    let Some(read_dir) = read_directory(dir)? else {
+        return Ok(());
+    };
+
+    for entry in read_dir {
+        let entry = entry.map_err(|err| {
+            CommandError::new(
+                ERROR_DISCOVERY_IO,
+                format!("Failed to inspect entry inside {}", dir.display()),
+                Some(err.to_string()),
+            )
+        })?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_voices_recursive(&path, voices, seen)?;
+            continue;
+        }
+
+        if is_voice_metadata(&path) {
+            if let Some(basename) = voice_basename(&path) {
+                let metadata = read_metadata(&path)?;
+                register_voice(voices, seen, basename, Some(metadata));
+            } else {
+                warn!(
+                    "Metadata file {} does not follow expected naming convention",
+                    path.display()
+                );
+            }
+            continue;
+        }
+
+        if is_voice_model(&path) {
+            let metadata_path = metadata_path_for_model(&path);
+            if metadata_path.exists() {
+                continue;
+            }
+            if let Some(basename) = voice_basename(&path) {
+                register_voice(voices, seen, basename, None);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn discover_voices_from(base: &Path) -> Result<Vec<VoicePreference>, CommandError> {
+    let mut voices = Vec::new();
+    collect_voices_from(base, &mut voices)?;
+    voices.sort_by(|a, b| a.label.cmp(&b.label).then_with(|| a.id.cmp(&b.id)));
+    Ok(voices)
+}
+
+#[tauri::command]
+pub fn list_voices() -> Result<Vec<VoicePreference>, CommandError> {
+    discover_voices_from(&voices_root())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::TempDir;
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn discovers_voices_from_metadata() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path().join("voices");
+        write_file(
+            &base.join("es_ES/es_ES-carlfm-x_low.onnx.json"),
+            r#"{
+    "language": { "code": "es_ES", "name_native": "Español" },
+    "dataset": "carlfm",
+    "audio": { "quality": "x_low" }
+}"#,
+        );
+
+        let voices = discover_voices_from(&base).unwrap();
+        assert_eq!(voices.len(), 1);
+        assert_eq!(voices[0].id, "es-ES-carlfm-x-low");
+        assert!(voices[0].label.contains("es-ES"));
+        assert!(voices[0].label.contains("Español") || voices[0].label.contains("CARLFM"));
+    }
+
+    #[test]
+    fn handles_missing_directory() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path().join("missing");
+        let voices = discover_voices_from(&base).unwrap();
+        assert!(voices.is_empty());
+    }
+
+    #[test]
+    fn invalid_metadata_reports_error() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path().join("voices");
+        write_file(&base.join("broken/bad.onnx.json"), "{ invalid json");
+
+        let error = discover_voices_from(&base).unwrap_err();
+        assert_eq!(error.code, ERROR_METADATA_INVALID);
+        assert!(error.message.contains("Invalid metadata"));
+    }
+}

--- a/src-tauri/src/cmds/voices.rs
+++ b/src-tauri/src/cmds/voices.rs
@@ -1,11 +1,9 @@
-use std::{
-    collections::HashSet,
-    ffi::OsString,
-    fs,
-    path::{Path, PathBuf},
-};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
 
-use log::{debug, warn};
+use log::debug;
 use serde::{Deserialize, Serialize};
 
 use super::speak::CommandError;
@@ -22,10 +20,16 @@ pub struct VoicePreference {
 #[derive(Debug, Deserialize, Default)]
 #[serde(default)]
 struct VoiceMetadata {
+    reader: Option<ReaderMetadata>,
     language: Option<LanguageMetadata>,
     dataset: Option<String>,
     audio: Option<AudioMetadata>,
-    reader: Option<ReaderMetadata>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+struct ReaderMetadata {
+    label: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -42,199 +46,33 @@ struct AudioMetadata {
     quality: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Default)]
-#[serde(default)]
-struct ReaderMetadata {
-    label: Option<String>,
-}
-
 fn voices_root() -> PathBuf {
     PathBuf::from("assets/voices")
 }
 
-fn read_directory(path: &Path) -> Result<Option<fs::ReadDir>, CommandError> {
-    match fs::read_dir(path) {
-        Ok(read_dir) => Ok(Some(read_dir)),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(err) => Err(CommandError::new(
-            ERROR_DISCOVERY_IO,
-            format!("Failed to read voices directory at {}", path.display()),
-            Some(err.to_string()),
-        )),
-    }
+fn discover_voices_from(base: &Path) -> Result<Vec<VoicePreference>, CommandError> {
+    let mut voices = BTreeMap::new();
+    visit_directory(base, &mut voices)?;
+
+    let mut preferences: Vec<VoicePreference> = voices
+        .into_iter()
+        .map(|(id, label)| VoicePreference { id, label })
+        .collect();
+    preferences.sort_by(|a, b| a.label.cmp(&b.label).then_with(|| a.id.cmp(&b.id)));
+    Ok(preferences)
 }
 
-fn is_voice_metadata(path: &Path) -> bool {
-    path.extension()
-        .and_then(|ext| ext.to_str())
-        .map(|ext| ext.eq_ignore_ascii_case("json"))
-        .unwrap_or(false)
-        && path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .map(|name| name.ends_with(".onnx.json"))
-            .unwrap_or(false)
-}
-
-fn is_voice_model(path: &Path) -> bool {
-    path.extension()
-        .and_then(|ext| ext.to_str())
-        .map(|ext| ext.eq_ignore_ascii_case("onnx"))
-        .unwrap_or(false)
-}
-
-fn metadata_path_for_model(path: &Path) -> PathBuf {
-    let mut os_string: OsString = path.as_os_str().to_os_string();
-    os_string.push(".json");
-    PathBuf::from(os_string)
-}
-
-fn voice_basename(path: &Path) -> Option<String> {
-    let file_name = path.file_name()?.to_str()?;
-    if let Some(name) = file_name.strip_suffix(".onnx.json") {
-        return Some(name.to_string());
-    }
-    if let Some(name) = file_name.strip_suffix(".onnx") {
-        return Some(name.to_string());
-    }
-    None
-}
-
-fn voice_id_from_basename(basename: &str) -> String {
-    basename.replace('_', "-")
-}
-
-fn read_metadata(path: &Path) -> Result<VoiceMetadata, CommandError> {
-    let content = fs::read_to_string(path).map_err(|err| {
-        CommandError::new(
-            ERROR_DISCOVERY_IO,
-            format!("Failed to read metadata at {}", path.display()),
-            Some(err.to_string()),
-        )
-    })?;
-
-    serde_json::from_str(&content).map_err(|err| {
-        CommandError::new(
-            ERROR_METADATA_INVALID,
-            format!("Invalid metadata for voice at {}", path.display()),
-            Some(err.to_string()),
-        )
-    })
-}
-
-fn format_language_label(metadata: &VoiceMetadata) -> Option<String> {
-    metadata.language.as_ref().map(|language| {
-        let code = language.code.as_deref().map(|code| code.replace('_', "-"));
-        let name = language
-            .name_native
-            .as_ref()
-            .filter(|value| !value.trim().is_empty())
-            .or_else(|| language.name_english.as_ref());
-
-        match (code, name) {
-            (Some(code), Some(name)) => format!("{code} - {name}"),
-            (Some(code), None) => code,
-            (None, Some(name)) => name.to_string(),
-            (None, None) => String::new(),
+fn visit_directory(dir: &Path, voices: &mut BTreeMap<String, String>) -> Result<(), CommandError> {
+    let read_dir = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(CommandError::new(
+                ERROR_DISCOVERY_IO,
+                format!("Failed to read voices directory at {}", dir.display()),
+                Some(err.to_string()),
+            ))
         }
-    })
-}
-
-fn title_case(value: &str) -> String {
-    value
-        .split(['-', '_', ' '])
-        .filter(|part| !part.is_empty())
-        .map(|part| {
-            if part.chars().all(|c| c.is_ascii_uppercase()) {
-                part.to_string()
-            } else {
-                let mut chars = part.chars();
-                match chars.next() {
-                    Some(first) => {
-                        format!("{}{}", first.to_uppercase(), chars.as_str().to_lowercase())
-                    }
-                    None => String::new(),
-                }
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn build_label(basename: &str, metadata: Option<&VoiceMetadata>) -> String {
-    if let Some(metadata) = metadata {
-        if let Some(label) = metadata
-            .reader
-            .as_ref()
-            .and_then(|reader| reader.label.as_ref())
-            .filter(|label| !label.trim().is_empty())
-        {
-            return label.trim().to_string();
-        }
-
-        let mut parts = Vec::new();
-        if let Some(language_label) =
-            format_language_label(metadata).filter(|value| !value.trim().is_empty())
-        {
-            parts.push(language_label);
-        }
-
-        if let Some(dataset) = metadata
-            .dataset
-            .as_ref()
-            .filter(|value| !value.trim().is_empty())
-        {
-            parts.push(title_case(dataset));
-        }
-
-        if let Some(quality) = metadata
-            .audio
-            .as_ref()
-            .and_then(|audio| audio.quality.as_ref())
-            .filter(|value| !value.trim().is_empty())
-        {
-            parts.push(title_case(quality));
-        }
-
-        if !parts.is_empty() {
-            return parts.join(" - ");
-        }
-    }
-
-    title_case(&basename.replace('_', " "))
-}
-
-fn register_voice(
-    voices: &mut Vec<VoicePreference>,
-    seen: &mut HashSet<String>,
-    basename: String,
-    metadata: Option<VoiceMetadata>,
-) {
-    let id = voice_id_from_basename(&basename);
-    if seen.contains(&id) {
-        debug!("Skipping duplicate voice id {id}");
-        return;
-    }
-    let label = build_label(&basename, metadata.as_ref());
-    voices.push(VoicePreference {
-        id: id.clone(),
-        label,
-    });
-    seen.insert(id);
-}
-
-fn collect_voices_from(dir: &Path, voices: &mut Vec<VoicePreference>) -> Result<(), CommandError> {
-    let mut seen = HashSet::new();
-    collect_voices_recursive(dir, voices, &mut seen)
-}
-
-fn collect_voices_recursive(
-    dir: &Path,
-    voices: &mut Vec<VoicePreference>,
-    seen: &mut HashSet<String>,
-) -> Result<(), CommandError> {
-    let Some(read_dir) = read_directory(dir)? else {
-        return Ok(());
     };
 
     for entry in read_dir {
@@ -245,44 +83,199 @@ fn collect_voices_recursive(
                 Some(err.to_string()),
             )
         })?;
+
         let path = entry.path();
         if path.is_dir() {
-            collect_voices_recursive(&path, voices, seen)?;
+            visit_directory(&path, voices)?;
             continue;
         }
 
-        if is_voice_metadata(&path) {
-            if let Some(basename) = voice_basename(&path) {
-                let metadata = read_metadata(&path)?;
-                register_voice(voices, seen, basename, Some(metadata));
-            } else {
-                warn!(
-                    "Metadata file {} does not follow expected naming convention",
-                    path.display()
-                );
-            }
+        if is_metadata_file(&path) {
+            register_voice_from_metadata(&path, voices)?;
             continue;
         }
 
         if is_voice_model(&path) {
-            let metadata_path = metadata_path_for_model(&path);
-            if metadata_path.exists() {
-                continue;
-            }
-            if let Some(basename) = voice_basename(&path) {
-                register_voice(voices, seen, basename, None);
-            }
+            register_voice_from_model(&path, voices);
         }
     }
 
     Ok(())
 }
 
-fn discover_voices_from(base: &Path) -> Result<Vec<VoicePreference>, CommandError> {
-    let mut voices = Vec::new();
-    collect_voices_from(base, &mut voices)?;
-    voices.sort_by(|a, b| a.label.cmp(&b.label).then_with(|| a.id.cmp(&b.id)));
-    Ok(voices)
+fn is_voice_model(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some(ext) if ext.eq_ignore_ascii_case("onnx")
+    )
+}
+
+fn is_metadata_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.ends_with(".onnx.json"))
+        .unwrap_or(false)
+}
+
+fn register_voice_from_model(path: &Path, voices: &mut BTreeMap<String, String>) {
+    if let Some(basename) = model_basename(path) {
+        let id = voice_id_from_basename(&basename);
+        voices
+            .entry(id)
+            .or_insert_with(|| default_label_from_basename(&basename));
+    }
+}
+
+fn register_voice_from_metadata(
+    path: &Path,
+    voices: &mut BTreeMap<String, String>,
+) -> Result<(), CommandError> {
+    let Some(basename) = metadata_basename(path) else {
+        debug!(
+            "Skipping metadata file {} because the name is not recognised",
+            path.display()
+        );
+        return Ok(());
+    };
+
+    let metadata = read_metadata(path)?;
+    let id = voice_id_from_basename(&basename);
+    let label = build_label(&basename, &metadata);
+    voices.insert(id, label);
+    Ok(())
+}
+
+fn model_basename(path: &Path) -> Option<String> {
+    let file_name = path.file_name()?.to_str()?;
+    file_name
+        .strip_suffix(".onnx")
+        .map(|value| value.to_string())
+}
+
+fn metadata_basename(path: &Path) -> Option<String> {
+    let file_name = path.file_name()?.to_str()?;
+    file_name
+        .strip_suffix(".onnx.json")
+        .map(|value| value.to_string())
+}
+
+fn voice_id_from_basename(basename: &str) -> String {
+    basename.replace('_', "-")
+}
+
+fn read_metadata(path: &Path) -> Result<VoiceMetadata, CommandError> {
+    let contents = fs::read_to_string(path).map_err(|err| {
+        CommandError::new(
+            ERROR_DISCOVERY_IO,
+            format!("Failed to read metadata at {}", path.display()),
+            Some(err.to_string()),
+        )
+    })?;
+
+    serde_json::from_str(&contents).map_err(|err| {
+        CommandError::new(
+            ERROR_METADATA_INVALID,
+            format!("Invalid metadata for voice at {}", path.display()),
+            Some(err.to_string()),
+        )
+    })
+}
+
+fn build_label(basename: &str, metadata: &VoiceMetadata) -> String {
+    if let Some(label) = metadata
+        .reader
+        .as_ref()
+        .and_then(|reader| reader.label.as_deref())
+        .and_then(|label| non_empty(label))
+    {
+        return label;
+    }
+
+    let mut label_parts = Vec::new();
+
+    if let Some(language) = metadata.language.as_ref().and_then(language_identifier) {
+        label_parts.push(language);
+    }
+
+    if let Some(dataset) = metadata
+        .dataset
+        .as_deref()
+        .and_then(non_empty)
+        .map(title_case)
+    {
+        label_parts.push(dataset);
+    }
+
+    let mut label = if label_parts.is_empty() {
+        default_label_from_basename(basename)
+    } else {
+        label_parts.join(" - ")
+    };
+
+    if let Some(quality) = metadata
+        .audio
+        .as_ref()
+        .and_then(|audio| audio.quality.as_deref())
+        .and_then(non_empty)
+        .map(title_case)
+    {
+        label = format!("{label} ({quality})");
+    }
+
+    label
+}
+
+fn language_identifier(metadata: &LanguageMetadata) -> Option<String> {
+    metadata
+        .code
+        .as_deref()
+        .and_then(non_empty)
+        .map(|code| code.replace('_', "-"))
+        .or_else(|| {
+            metadata
+                .name_native
+                .as_deref()
+                .and_then(non_empty)
+                .map(|name| name.to_string())
+        })
+        .or_else(|| {
+            metadata
+                .name_english
+                .as_deref()
+                .and_then(non_empty)
+                .map(|name| name.to_string())
+        })
+}
+
+fn default_label_from_basename(basename: &str) -> String {
+    title_case(&basename.replace('_', " "))
+}
+
+fn title_case(value: &str) -> String {
+    value
+        .split_whitespace()
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(first) => {
+                    let mut cased = first.to_uppercase().collect::<String>();
+                    cased.push_str(&chars.as_str().to_lowercase());
+                    cased
+                }
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn non_empty(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 #[tauri::command]
@@ -295,35 +288,37 @@ mod tests {
     use super::*;
     use assert_fs::TempDir;
 
-    fn write_file(path: &Path, content: &str) {
+    fn write_file(path: &Path, contents: &str) {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).unwrap();
         }
-        fs::write(path, content).unwrap();
+        fs::write(path, contents).unwrap();
     }
 
     #[test]
     fn discovers_voices_from_metadata() {
         let temp = TempDir::new().unwrap();
-        let base = temp.path().join("voices");
+        let base = temp.path();
+        let metadata_path = base.join("es_ES/es_ES-carlfm-x_low.onnx.json");
         write_file(
-            &base.join("es_ES/es_ES-carlfm-x_low.onnx.json"),
+            &metadata_path,
             r#"{
-    "language": { "code": "es_ES", "name_native": "Español" },
+    "reader": { "label": "CarlFM" },
+    "language": { "code": "es_ES" },
     "dataset": "carlfm",
     "audio": { "quality": "x_low" }
 }"#,
         );
+        write_file(&base.join("es_ES/es_ES-carlfm-x_low.onnx"), "dummy-model");
 
-        let voices = discover_voices_from(&base).unwrap();
+        let voices = discover_voices_from(base).unwrap();
         assert_eq!(voices.len(), 1);
         assert_eq!(voices[0].id, "es-ES-carlfm-x-low");
-        assert!(voices[0].label.contains("es-ES"));
-        assert!(voices[0].label.contains("Español") || voices[0].label.contains("CARLFM"));
+        assert_eq!(voices[0].label, "CarlFM");
     }
 
     #[test]
-    fn handles_missing_directory() {
+    fn returns_empty_when_directory_missing() {
         let temp = TempDir::new().unwrap();
         let base = temp.path().join("missing");
         let voices = discover_voices_from(&base).unwrap();
@@ -331,13 +326,25 @@ mod tests {
     }
 
     #[test]
-    fn invalid_metadata_reports_error() {
+    fn invalid_metadata_returns_error() {
         let temp = TempDir::new().unwrap();
-        let base = temp.path().join("voices");
-        write_file(&base.join("broken/bad.onnx.json"), "{ invalid json");
+        let base = temp.path();
+        write_file(&base.join("broken/voice.onnx.json"), "{ not valid");
 
-        let error = discover_voices_from(&base).unwrap_err();
+        let error = discover_voices_from(base).unwrap_err();
         assert_eq!(error.code, ERROR_METADATA_INVALID);
         assert!(error.message.contains("Invalid metadata"));
+    }
+
+    #[test]
+    fn discovers_model_without_metadata() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+        write_file(&base.join("fr_FR/fr_sample.onnx"), "model");
+
+        let voices = discover_voices_from(base).unwrap();
+        assert_eq!(voices.len(), 1);
+        assert_eq!(voices[0].id, "fr-FR-fr-sample");
+        assert_eq!(voices[0].label, "Fr Fr Fr Sample");
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,7 +3,7 @@ use std::{fs, path::PathBuf};
 use log::{error, info};
 mod cmds;
 
-use cmds::{import_epub, import_pdf, speak};
+use cmds::{import_epub, import_pdf, list_voices, speak};
 
 fn init_logging() {
     let logs_dir = PathBuf::from("logs");
@@ -39,7 +39,7 @@ fn main() {
     info!("Starting Reader Tauri backend");
 
     if let Err(err) = tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![speak, import_pdf, import_epub])
+        .invoke_handler(tauri::generate_handler![speak, import_pdf, import_epub, list_voices])
         .run(tauri::generate_context!())
     {
         error!("Tauri runtime error: {err:?}");


### PR DESCRIPTION
## Summary
- add a `list_voices` Tauri command that discovers voice metadata under `assets/voices`
- expose the new command through the command module and Tauri handler so the frontend can invoke it
- cover voice discovery, empty directories, and invalid metadata with unit tests

## Testing
- `cargo test` *(fails: unable to download crates index due to 403 CONNECT tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68de5ae978708328a411104fac388cff