### PR TITLE
Add phonetic dictionary support for speech synthesis

### DIFF
--- a/src-tauri/src/cmds/import_epub.rs
+++ b/src-tauri/src/cmds/import_epub.rs
@@ -80,10 +80,8 @@ print(json.dumps({
     #[test]
     fn importer_failure_is_reported() {
         let temp = TempDir::new().unwrap();
-        let _guard = write_mock_importer(
-            &temp,
-            "import sys\nsys.stderr.write('kaput')\nsys.exit(2)",
-        );
+        let _guard =
+            write_mock_importer(&temp, "import sys\nsys.stderr.write('kaput')\nsys.exit(2)");
         let request = sample_request(&temp);
         let error = import_epub(request).unwrap_err();
         assert_eq!(error.code, import_pdf::ERROR_SCRIPT_FAILED);

--- a/src-tauri/src/cmds/import_pdf.rs
+++ b/src-tauri/src/cmds/import_pdf.rs
@@ -122,7 +122,11 @@ pub(crate) fn run_importer(
         return Err(CommandError::new(
             ERROR_SCRIPT_FAILED,
             format!("Importer exited with status {:?}", output.status.code()),
-            if stderr.is_empty() { None } else { Some(stderr) },
+            if stderr.is_empty() {
+                None
+            } else {
+                Some(stderr)
+            },
         ));
     }
 
@@ -154,10 +158,7 @@ pub(crate) fn run_importer(
         })
         .collect::<Result<Vec<_>, CommandError>>()?;
 
-    let metadata = raw
-        .metadata
-        .map(Value::Object)
-        .unwrap_or(Value::Null);
+    let metadata = raw.metadata.map(Value::Object).unwrap_or(Value::Null);
 
     Ok(ImportResponse {
         document: ImportedDocument {
@@ -244,10 +245,8 @@ print(json.dumps({
     #[test]
     fn importer_error_returns_script_error() {
         let temp = TempDir::new().unwrap();
-        let _guard = write_mock_importer(
-            &temp,
-            "import sys\nsys.stderr.write('fail')\nsys.exit(1)",
-        );
+        let _guard =
+            write_mock_importer(&temp, "import sys\nsys.stderr.write('fail')\nsys.exit(1)");
         let request = sample_request(&temp);
         let error = import_pdf(request).unwrap_err();
         assert_eq!(error.code, ERROR_SCRIPT_FAILED);

--- a/src-tauri/src/cmds/mod.rs
+++ b/src-tauri/src/cmds/mod.rs
@@ -8,5 +8,5 @@ pub use speak::speak;
 
 pub use import_epub::ImportEpubRequest;
 pub use import_pdf::ImportPdfRequest;
-pub use speak::SpeakRequest;
 pub use speak::CommandError;
+pub use speak::SpeakRequest;

--- a/src-tauri/src/cmds/speak.rs
+++ b/src-tauri/src/cmds/speak.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 use shlex::Shlex;
 use thiserror::Error;
 
+use crate::dict::PhoneticDictionary;
+
 const ERROR_VOICE_NOT_FOUND: &str = "VOICE_NOT_FOUND";
 const ERROR_PROCESS_FAILED: &str = "PROCESS_FAILED";
 const ERROR_IO: &str = "IO_ERROR";
@@ -53,19 +55,15 @@ impl From<CommandFailure> for CommandError {
                 format!("Voice model not found: {}", path.display()),
                 None,
             ),
-            CommandFailure::SpawnFailure(err) => CommandError::new(
-                ERROR_IO,
-                "Failed to launch Piper",
-                Some(err.to_string()),
-            ),
+            CommandFailure::SpawnFailure(err) => {
+                CommandError::new(ERROR_IO, "Failed to launch Piper", Some(err.to_string()))
+            }
             CommandFailure::PiperFailure { status, stderr } => CommandError::new(
                 ERROR_PROCESS_FAILED,
                 format!("Piper exited with status {status}"),
                 Some(stderr),
             ),
-            CommandFailure::Other(message) => {
-                CommandError::new(ERROR_INTERNAL, message, None)
-            }
+            CommandFailure::Other(message) => CommandError::new(ERROR_INTERNAL, message, None),
         }
     }
 }
@@ -164,9 +162,10 @@ impl PiperInvoker for DefaultPiperInvoker {
             .spawn()
             .map_err(CommandFailure::SpawnFailure)?;
         {
-            let stdin = child.stdin.as_mut().ok_or_else(|| {
-                CommandFailure::Other("Failed to access Piper stdin".into())
-            })?;
+            let stdin = child
+                .stdin
+                .as_mut()
+                .ok_or_else(|| CommandFailure::Other("Failed to access Piper stdin".into()))?;
             stdin
                 .write_all(request.text.as_bytes())
                 .map_err(|err| CommandFailure::Other(err.to_string()))?;
@@ -179,10 +178,7 @@ impl PiperInvoker for DefaultPiperInvoker {
 
         if !output.status.success() {
             let code = output.status.code().unwrap_or_default();
-            error!(
-                "Piper command exited with status {code}: {}",
-                stderr
-            );
+            error!("Piper command exited with status {code}: {}", stderr);
             return Err(CommandFailure::PiperFailure {
                 status: code,
                 stderr,
@@ -199,24 +195,35 @@ impl PiperInvoker for DefaultPiperInvoker {
         Ok(SpeakResponse {
             output_path: request.output_path.clone(),
             duration_ms,
-            stderr: if stderr.is_empty() { None } else { Some(stderr) },
+            stderr: if stderr.is_empty() {
+                None
+            } else {
+                Some(stderr)
+            },
         })
     }
 }
 
-pub fn speak(request: SpeakRequest) -> Result<SpeakResponse, CommandError> {
+pub fn speak(mut request: SpeakRequest) -> Result<SpeakResponse, CommandError> {
     info!(
         "Invoking Piper for model {} writing to {}",
         request.model_path.display(),
         request.output_path.display()
     );
 
-    DefaultPiperInvoker
-        .invoke(&request)
-        .map_err(|err| {
-            error!("Speak command failed: {err}");
-            CommandError::from(err)
-        })
+    match PhoneticDictionary::load_from_env() {
+        Ok(dictionary) => {
+            request.text = dictionary.transform_text(&request.text);
+        }
+        Err(err) => {
+            warn!("Failed to load phonetic dictionary: {err}");
+        }
+    }
+
+    DefaultPiperInvoker.invoke(&request).map_err(|err| {
+        error!("Speak command failed: {err}");
+        CommandError::from(err)
+    })
 }
 
 #[cfg(test)]
@@ -268,7 +275,8 @@ mod tests {
     #[test]
     fn speak_success_creates_audio() {
         let temp = TempDir::new().unwrap();
-        let _guard = write_mock_piper_script(&temp, 
+        let _guard = write_mock_piper_script(
+            &temp,
             r#"import argparse
 import sys
 parser = argparse.ArgumentParser()

--- a/src-tauri/src/dict/mod.rs
+++ b/src-tauri/src/dict/mod.rs
@@ -2,3 +2,251 @@
 //!
 //! Persist custom lexicon entries (JSON/SQLite) and expose helpers for
 //! mapping words to phonetic sequences compatible with Piper.
+
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const DEFAULT_DICTIONARY_PATH: &str = "runtime/phonetic_dictionary.json";
+const DICTIONARY_PATH_ENV: &str = "READER_DICTIONARY_PATH";
+
+fn canonical_key(word: &str) -> String {
+    word.trim().to_lowercase()
+}
+
+fn is_token_character(ch: char) -> bool {
+    ch.is_alphanumeric() || matches!(ch, '\'' | '-')
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DictionaryEntry {
+    pub word: String,
+    pub phonemes: String,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct DictionaryFile {
+    entries: Vec<DictionaryEntry>,
+}
+
+#[derive(Debug, Error)]
+pub enum DictionaryError {
+    #[error("failed to read dictionary at {path:?}: {source}")]
+    ReadFailure {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to parse dictionary at {path:?}: {source}")]
+    ParseFailure {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    #[error("failed to write dictionary at {path:?}: {source}")]
+    WriteFailure {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to serialise dictionary for {path:?}: {source}")]
+    SerialiseFailure {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct PhoneticDictionary {
+    path: PathBuf,
+    entries: HashMap<String, DictionaryEntry>,
+}
+
+impl PhoneticDictionary {
+    pub fn load(path: impl Into<PathBuf>) -> Result<Self, DictionaryError> {
+        let path = path.into();
+        let entries = if path.exists() {
+            let contents =
+                fs::read_to_string(&path).map_err(|source| DictionaryError::ReadFailure {
+                    path: path.clone(),
+                    source,
+                })?;
+
+            if contents.trim().is_empty() {
+                Vec::new()
+            } else {
+                let file: DictionaryFile = serde_json::from_str(&contents).map_err(|source| {
+                    DictionaryError::ParseFailure {
+                        path: path.clone(),
+                        source,
+                    }
+                })?;
+                file.entries
+            }
+        } else {
+            Vec::new()
+        };
+
+        Ok(Self {
+            path,
+            entries: entries
+                .into_iter()
+                .map(|entry| (canonical_key(&entry.word), entry))
+                .collect(),
+        })
+    }
+
+    pub fn load_from_env() -> Result<Self, DictionaryError> {
+        let path = std::env::var_os(DICTIONARY_PATH_ENV)
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_DICTIONARY_PATH));
+        Self::load(path)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn save(&self) -> Result<(), DictionaryError> {
+        if let Some(parent) = self.path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent).map_err(|source| DictionaryError::WriteFailure {
+                    path: parent.to_path_buf(),
+                    source,
+                })?;
+            }
+        }
+
+        let mut entries: Vec<_> = self.entries.values().cloned().collect();
+        entries.sort_by(|a, b| a.word.to_lowercase().cmp(&b.word.to_lowercase()));
+
+        let file = DictionaryFile { entries };
+        let payload = serde_json::to_string_pretty(&file).map_err(|source| {
+            DictionaryError::SerialiseFailure {
+                path: self.path.clone(),
+                source,
+            }
+        })?;
+
+        fs::write(&self.path, payload).map_err(|source| DictionaryError::WriteFailure {
+            path: self.path.clone(),
+            source,
+        })
+    }
+
+    pub fn get(&self, word: &str) -> Option<&DictionaryEntry> {
+        self.entries.get(&canonical_key(word))
+    }
+
+    pub fn get_phonemes(&self, word: &str) -> Option<&str> {
+        self.get(word).map(|entry| entry.phonemes.as_str())
+    }
+
+    pub fn insert(
+        &mut self,
+        word: impl Into<String>,
+        phonemes: impl Into<String>,
+    ) -> Option<DictionaryEntry> {
+        let entry = DictionaryEntry {
+            word: word.into(),
+            phonemes: phonemes.into(),
+        };
+        self.entries.insert(canonical_key(&entry.word), entry)
+    }
+
+    pub fn upsert_entry(&mut self, entry: DictionaryEntry) -> Option<DictionaryEntry> {
+        self.entries.insert(canonical_key(&entry.word), entry)
+    }
+
+    pub fn remove(&mut self, word: &str) -> Option<DictionaryEntry> {
+        self.entries.remove(&canonical_key(word))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn entries(&self) -> impl Iterator<Item = &DictionaryEntry> {
+        self.entries.values()
+    }
+
+    pub fn transform_text(&self, text: &str) -> String {
+        if self.entries.is_empty() {
+            return text.to_string();
+        }
+
+        let mut result = String::with_capacity(text.len());
+        let mut token = String::new();
+
+        for ch in text.chars() {
+            if is_token_character(ch) {
+                token.push(ch);
+            } else {
+                self.flush_token(&mut token, &mut result);
+                result.push(ch);
+            }
+        }
+
+        self.flush_token(&mut token, &mut result);
+        result
+    }
+
+    fn flush_token(&self, token: &mut String, output: &mut String) {
+        if token.is_empty() {
+            return;
+        }
+
+        if let Some(entry) = self.get(token) {
+            output.push_str(&entry.phonemes);
+        } else {
+            output.push_str(token);
+        }
+
+        token.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_missing_dictionary_creates_empty_store() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("missing.json");
+        let dictionary = PhoneticDictionary::load(&path).unwrap();
+        assert!(dictionary.is_empty());
+        assert_eq!(dictionary.path(), path.as_path());
+    }
+
+    #[test]
+    fn persist_and_reload_entries() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("lexicon.json");
+        let mut dictionary = PhoneticDictionary::load(&path).unwrap();
+        dictionary.insert("gif", "JH IH1 F");
+        dictionary.insert("SQL", "S Q L");
+        dictionary.save().unwrap();
+
+        let reloaded = PhoneticDictionary::load(&path).unwrap();
+        assert_eq!(reloaded.get_phonemes("gif"), Some("JH IH1 F"));
+        assert_eq!(reloaded.get_phonemes("sql"), Some("S Q L"));
+    }
+
+    #[test]
+    fn transform_text_replaces_tokens() {
+        use std::collections::HashMap;
+
+        let mut dictionary = PhoneticDictionary {
+            path: PathBuf::from("memory"),
+            entries: HashMap::new(),
+        };
+        dictionary.insert("gif", "JH IH1 F");
+        dictionary.insert("Na", "N EY1");
+        let text = "Play that GIF, Na!";
+        let transformed = dictionary.transform_text(text);
+        assert_eq!(transformed, "Play that JH IH1 F, N EY1!");
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,7 @@ use std::{fs, path::PathBuf};
 
 use log::{error, info};
 mod cmds;
+mod dict;
 
 use cmds::{import_epub, import_pdf, speak};
 
@@ -11,25 +12,23 @@ fn init_logging() {
         eprintln!("Failed to create log directory {logs_dir:?}: {err}");
     }
 
-    if let Err(err) = flexi_logger::Logger::try_with_env_or_str("info")
-        .and_then(|logger| {
-            logger
-                .log_to_file(
-                    flexi_logger::FileSpec::default()
-                        .directory(&logs_dir)
-                        .basename("reader")
-                        .suffix("log")
-                        .suppress_timestamp(),
-                )
-                .rotate(
-                    flexi_logger::Criterion::Size(5_000_000),
-                    flexi_logger::Naming::Numbers,
-                    flexi_logger::Cleanup::KeepLogFiles(5),
-                )
-                .duplicate_to_stderr(flexi_logger::Duplicate::Info)
-                .start()
-        })
-    {
+    if let Err(err) = flexi_logger::Logger::try_with_env_or_str("info").and_then(|logger| {
+        logger
+            .log_to_file(
+                flexi_logger::FileSpec::default()
+                    .directory(&logs_dir)
+                    .basename("reader")
+                    .suffix("log")
+                    .suppress_timestamp(),
+            )
+            .rotate(
+                flexi_logger::Criterion::Size(5_000_000),
+                flexi_logger::Naming::Numbers,
+                flexi_logger::Cleanup::KeepLogFiles(5),
+            )
+            .duplicate_to_stderr(flexi_logger::Duplicate::Info)
+            .start()
+    }) {
         eprintln!("Failed to initialise logger: {err}");
     }
 }


### PR DESCRIPTION
## Summary
- add a phonetic dictionary module with JSON persistence, CRUD helpers, and token transformation logic
- integrate the dictionary into the speak command to normalise text before invoking Piper
- add unit tests covering dictionary persistence and lookup/transform behaviour

## Testing
- cargo test *(fails: unable to download crates index due to 403 CONNECT tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68de5af4850083289fa7382e61cd79b9